### PR TITLE
Do a Barrel Roll!

### DIFF
--- a/Assets/Prefabs/Exterior/Enemies/Asteroids/ExteriorEnemyRock.prefab
+++ b/Assets/Prefabs/Exterior/Enemies/Asteroids/ExteriorEnemyRock.prefab
@@ -14,7 +14,7 @@ GameObject:
   - component: {fileID: 7139926870183664444}
   - component: {fileID: -4036976034239442463}
   - component: {fileID: -278988709436758044}
-  - component: {fileID: 5299537212655491360}
+  - component: {fileID: -7165483459144256337}
   m_Layer: 17
   m_Name: ExteriorEnemyRock
   m_TagString: Asteroid
@@ -233,7 +233,7 @@ MonoBehaviour:
     flameOdds: 5
     breachOdds: 10
     numProblems: 3
---- !u!114 &5299537212655491360
+--- !u!114 &-7165483459144256337
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -247,6 +247,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   resourcePrefab: {fileID: 1346024567363085296, guid: 363461cbd48a8bd44b2475ac184559d6,
     type: 3}
-  dropChanceOnDestroy: 0
-  dropChanceOnHit: 0.2
-  dropCount: 1
+  dropChanceOnDestroy: 1
+  dropChanceOnHit: 0
+  dropCount: 5

--- a/Assets/Prefabs/Exterior/Enemies/Asteroids/ExteriorEnemyRockMedium.prefab
+++ b/Assets/Prefabs/Exterior/Enemies/Asteroids/ExteriorEnemyRockMedium.prefab
@@ -174,6 +174,8 @@ MonoBehaviour:
       m_Calls: []
   explosionPrefab: {fileID: 235347168054186532, guid: 6a990f3b44005534986bd67b0c61ed91,
     type: 3}
+  explosionSFXOverride: {fileID: 0}
+  explosionVolume: 0.5
   childAsteroidPrefabs:
   - {fileID: 4303212633405705334, guid: f64466e5867c8de4c96bc6239d171ade, type: 3}
   - {fileID: 4303212633405705334, guid: f64466e5867c8de4c96bc6239d171ade, type: 3}
@@ -204,6 +206,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   resourcePrefab: {fileID: 1346024567363085296, guid: 363461cbd48a8bd44b2475ac184559d6,
     type: 3}
-  dropChanceOnDestroy: 0.1
+  dropChanceOnDestroy: 0
   dropChanceOnHit: 0
-  dropCount: 1
+  dropCount: 0

--- a/Assets/Prefabs/Exterior/Enemies/Asteroids/ExteriorEnemyRockMediumResource.prefab
+++ b/Assets/Prefabs/Exterior/Enemies/Asteroids/ExteriorEnemyRockMediumResource.prefab
@@ -205,4 +205,4 @@ MonoBehaviour:
     type: 3}
   dropChanceOnDestroy: 1
   dropChanceOnHit: 0
-  dropCount: 1
+  dropCount: 3

--- a/Assets/Prefabs/Exterior/Enemies/ExteriorEnemyShipBigBoi.prefab
+++ b/Assets/Prefabs/Exterior/Enemies/ExteriorEnemyShipBigBoi.prefab
@@ -334,6 +334,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   resourcePrefab: {fileID: 1346024567363085296, guid: 363461cbd48a8bd44b2475ac184559d6,
     type: 3}
-  dropChanceOnDestroy: 0.5
+  dropChanceOnDestroy: 1
   dropChanceOnHit: 0
   dropCount: 1

--- a/Assets/Prefabs/Exterior/Enemies/ExteriorEnemyShipPlainJane.prefab
+++ b/Assets/Prefabs/Exterior/Enemies/ExteriorEnemyShipPlainJane.prefab
@@ -186,7 +186,7 @@ MonoBehaviour:
     flameOdds: 10
     breachOdds: 20
     numProblems: 1
-  spreadShot: 1
+  spreadShot: 0
 --- !u!50 &942606664080155765
 Rigidbody2D:
   serializedVersion: 4
@@ -334,6 +334,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   resourcePrefab: {fileID: 1346024567363085296, guid: 363461cbd48a8bd44b2475ac184559d6,
     type: 3}
-  dropChanceOnDestroy: 0.2
+  dropChanceOnDestroy: 0.9
   dropChanceOnHit: 0
   dropCount: 1

--- a/Assets/Prefabs/Exterior/Enemies/ExteriorEnemyShipSpeedster.prefab
+++ b/Assets/Prefabs/Exterior/Enemies/ExteriorEnemyShipSpeedster.prefab
@@ -334,6 +334,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   resourcePrefab: {fileID: 1346024567363085296, guid: 363461cbd48a8bd44b2475ac184559d6,
     type: 3}
-  dropChanceOnDestroy: 0.1
+  dropChanceOnDestroy: 0.5
   dropChanceOnHit: 0
   dropCount: 1

--- a/Assets/Prefabs/Exterior/ExteriorPlayerBallProjectileLaser.prefab
+++ b/Assets/Prefabs/Exterior/ExteriorPlayerBallProjectileLaser.prefab
@@ -97,7 +97,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   explosionPrefab: {fileID: 0}
-  speed: 10
+  speed: 20
   damage: 20
   indestructable: 1
   spin: 1000

--- a/Assets/Prefabs/Exterior/ExteriorPlayerShip.prefab
+++ b/Assets/Prefabs/Exterior/ExteriorPlayerShip.prefab
@@ -5127,6 +5127,39 @@ ParticleSystemRenderer:
   m_Mesh2: {fileID: 0}
   m_Mesh3: {fileID: 0}
   m_MaskInteraction: 0
+--- !u!1 &830175073578282520
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6771386732470129650}
+  m_Layer: 8
+  m_Name: ProjectileSpawns
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6771386732470129650
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 830175073578282520}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 2709358209152170433}
+  - {fileID: 7524648171207930794}
+  - {fileID: 5849561316962717907}
+  m_Father: {fileID: 2709358210058121327}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2158722598810028220
 GameObject:
   m_ObjectHideFlags: 0
@@ -9891,7 +9924,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2709358209152170433}
   m_Layer: 8
-  m_Name: Projectile Spawn
+  m_Name: ProjectileSpawn_Front
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -9904,11 +9937,11 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2709358209152170446}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0.427, z: 0}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.42700005, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 2709358210058121327}
+  m_Father: {fileID: 6771386732470129650}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2709358210058121325
@@ -9943,7 +9976,7 @@ Transform:
   m_LocalPosition: {x: -0.082959935, y: -3.9919033, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
-  - {fileID: 2709358209152170433}
+  - {fileID: 6771386732470129650}
   - {fileID: 1835685780}
   - {fileID: 1950095768}
   - {fileID: 374391292}
@@ -10020,11 +10053,13 @@ MonoBehaviour:
       m_Calls: []
   maxHitPoints: 5
   invincible: 0
-  speed: 25
+  speed: 30
   speedBoostMult: 1
   maxSpeed: 100
-  fireRate: 3
-  fireRateBoost: 0
+  fireRateLeft: 3
+  fireRateBoostLeft: 0
+  fireRateRight: 3
+  fireRateBoostRight: 0
   projectilePrefab: {fileID: 2989912971476457516, guid: 85bde06338b7eac4da4e14c331c0bcf1,
     type: 3}
   energyBallPrefab: {fileID: 5470119547413587598, guid: 5bac6f22ce59442438f0dd9c972f5408,
@@ -10033,7 +10068,9 @@ MonoBehaviour:
     type: 3}
   exteriorManager: {fileID: 0}
   interiorManager: {fileID: 0}
-  projectileSpawnTransform: {fileID: 2709358209152170433}
+  projSpawnFront: {fileID: 2709358209152170433}
+  projSpawnLeft: {fileID: 7524648171207930794}
+  projSpawnRight: {fileID: 5849561316962717907}
   damageSprites:
   - {fileID: 21300000, guid: f6d494a90fd8b994aa8cb7d208bec6cd, type: 3}
   - {fileID: 21300000, guid: e1cd239e807c97f4e9911195742e43c7, type: 3}
@@ -10049,6 +10086,12 @@ MonoBehaviour:
   engineFlameEffect: {fileID: 5246661234678222050}
   engineSmokeEffect: {fileID: 2158722598810028220}
   engineTrailEffect: {fileID: 180218295115296052}
+  currentHitPoints: 5
+  crippledSpeedMult: 1
+  spreadStacks: []
+  engineBoostStacks: []
+  fireRateBoostStacksLeft: []
+  fireRateBoostStacksRight: []
   shields: 0
 --- !u!60 &2709358210058121313
 PolygonCollider2D:
@@ -10307,3 +10350,63 @@ Animator:
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorControllerStateOnDisable: 0
+--- !u!1 &5929025361165289592
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5849561316962717907}
+  m_Layer: 8
+  m_Name: ProjectileSpawn_Right
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5849561316962717907
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5929025361165289592}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.43, y: -0.055, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 6771386732470129650}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &8782980709767699481
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7524648171207930794}
+  m_Layer: 8
+  m_Name: ProjectileSpawn_Left
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7524648171207930794
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8782980709767699481}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0.43, y: -0.055, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 6771386732470129650}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Prefabs/Exterior/ExternalResourcePickup.prefab
+++ b/Assets/Prefabs/Exterior/ExternalResourcePickup.prefab
@@ -124,4 +124,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 879c8f9dab7c2694c976b514e281c0bf, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  speed: 0.5
+  speed: 1

--- a/Assets/Prefabs/Interior/InteriorPlayer.prefab
+++ b/Assets/Prefabs/Interior/InteriorPlayer.prefab
@@ -100,6 +100,7 @@ MonoBehaviour:
   speed: 100
   velocity: {x: 0, y: 0}
   playerID: 0
+  pickupRadius: 0.3
 --- !u!58 &4133146544276248400
 CircleCollider2D:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/NickTest.unity
+++ b/Assets/Scenes/NickTest.unity
@@ -929,12 +929,12 @@ PrefabInstance:
     - target: {fileID: 4660719601325771399, guid: 5fce5f9d81cb36d4e8d04d1f8ea7e08e,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -3.89
+      value: -4.08
       objectReference: {fileID: 0}
     - target: {fileID: 4660719601325771399, guid: 5fce5f9d81cb36d4e8d04d1f8ea7e08e,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.91
+      value: 1.58
       objectReference: {fileID: 0}
     - target: {fileID: 4660719601325771399, guid: 5fce5f9d81cb36d4e8d04d1f8ea7e08e,
         type: 3}
@@ -964,7 +964,7 @@ PrefabInstance:
     - target: {fileID: 4660719601325771399, guid: 5fce5f9d81cb36d4e8d04d1f8ea7e08e,
         type: 3}
       propertyPath: m_RootOrder
-      value: 20
+      value: 17
       objectReference: {fileID: 0}
     - target: {fileID: 4660719601325771399, guid: 5fce5f9d81cb36d4e8d04d1f8ea7e08e,
         type: 3}
@@ -1094,6 +1094,228 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 40, y: 1}
   m_EdgeRadius: 0
+--- !u!1 &175075018
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 175075019}
+  - component: {fileID: 175075023}
+  - component: {fileID: 175075022}
+  - component: {fileID: 175075021}
+  - component: {fileID: 175075020}
+  m_Layer: 14
+  m_Name: WeaponRepeaterStationRight
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &175075019
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 175075018}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -3.284, y: 0.99, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1343496270}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!82 &175075020
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 175075018}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 0}
+  m_audioClip: {fileID: 0}
+  m_PlayOnAwake: 0
+  m_Volume: 1
+  m_Pitch: 1
+  Loop: 0
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+--- !u!114 &175075021
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 175075018}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8c7d23d8f3aca3a4884c6731a036e9ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  exteriorShip: {fileID: 0}
+  activated: 1
+  resourceRequirement: 1
+  resourceCount: 0
+  resourcePipPrefab: {fileID: 4364623327053348872, guid: c93aa1eecbae35c448ae84a8fd966803,
+    type: 3}
+  addResourceSFX: {fileID: 8300000, guid: 6038f9e6cf9f0b6439b795cbf001c388, type: 3}
+  doEffectSFX: {fileID: 8300000, guid: c3cd6fad04cc7cb4da2f9c05c4f63081, type: 3}
+  disableSFX: {fileID: 8300000, guid: db9c42ae04551ce49978816123ad803b, type: 3}
+  boostMultPerResource: 1
+  duration: 25
+  maxStacks: 5
+  leftGun: 0
+  rightGun: 1
+--- !u!58 &175075022
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 175075018}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  serializedVersion: 2
+  m_Radius: 0.25
+--- !u!212 &175075023
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 175075018}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: -1877029187
+  m_SortingLayer: 7
+  m_SortingOrder: 1
+  m_Sprite: {fileID: 21300000, guid: be3bc5205b1120f449639cb93098e8dc, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 0.38, y: 0.37}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
 --- !u!1 &192176227
 GameObject:
   m_ObjectHideFlags: 0
@@ -1154,12 +1376,6 @@ Transform:
   m_Father: {fileID: 1641571281}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &225548367 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 5428338951377334393, guid: 4a9a2a554924169449c262911cfacac3,
-    type: 3}
-  m_PrefabInstance: {fileID: 5428338952980910459}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &251912151
 GameObject:
   m_ObjectHideFlags: 0
@@ -1487,23 +1703,15 @@ Transform:
   - {fileID: 1343496270}
   - {fileID: 1428635884}
   - {fileID: 289846043}
-  - {fileID: 225548367}
-  - {fileID: 361009602}
   - {fileID: 1209525302}
   - {fileID: 586683824}
   - {fileID: 323229168}
   - {fileID: 4960148901419560201}
-  - {fileID: 470282451}
   - {fileID: 126840537}
+  - {fileID: 1148884738}
   m_Father: {fileID: 0}
   m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &361009602 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 5926554707891443729, guid: 25228b40e8283f744ab81d3b828807b8,
-    type: 3}
-  m_PrefabInstance: {fileID: 4166267193701828184}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &410399001
 GameObject:
   m_ObjectHideFlags: 0
@@ -1938,12 +2146,6 @@ AudioSource:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
---- !u!4 &470282451 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4493216524806061763, guid: 5de765d239be8b6419a76f97028bd244,
-    type: 3}
-  m_PrefabInstance: {fileID: 1826829106}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &480817478
 GameObject:
   m_ObjectHideFlags: 0
@@ -2148,12 +2350,12 @@ PrefabInstance:
     - target: {fileID: 4660719601325771399, guid: 5fce5f9d81cb36d4e8d04d1f8ea7e08e,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -3.93
+      value: -4.84
       objectReference: {fileID: 0}
     - target: {fileID: 4660719601325771399, guid: 5fce5f9d81cb36d4e8d04d1f8ea7e08e,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.77
+      value: 1.05
       objectReference: {fileID: 0}
     - target: {fileID: 4660719601325771399, guid: 5fce5f9d81cb36d4e8d04d1f8ea7e08e,
         type: 3}
@@ -2183,7 +2385,7 @@ PrefabInstance:
     - target: {fileID: 4660719601325771399, guid: 5fce5f9d81cb36d4e8d04d1f8ea7e08e,
         type: 3}
       propertyPath: m_RootOrder
-      value: 17
+      value: 15
       objectReference: {fileID: 0}
     - target: {fileID: 4660719601325771399, guid: 5fce5f9d81cb36d4e8d04d1f8ea7e08e,
         type: 3}
@@ -2304,12 +2506,12 @@ PrefabInstance:
     - target: {fileID: 4660719601325771399, guid: 5fce5f9d81cb36d4e8d04d1f8ea7e08e,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -4.09
+      value: -4.51
       objectReference: {fileID: 0}
     - target: {fileID: 4660719601325771399, guid: 5fce5f9d81cb36d4e8d04d1f8ea7e08e,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.92
+      value: 1.44
       objectReference: {fileID: 0}
     - target: {fileID: 4660719601325771399, guid: 5fce5f9d81cb36d4e8d04d1f8ea7e08e,
         type: 3}
@@ -2339,7 +2541,7 @@ PrefabInstance:
     - target: {fileID: 4660719601325771399, guid: 5fce5f9d81cb36d4e8d04d1f8ea7e08e,
         type: 3}
       propertyPath: m_RootOrder
-      value: 16
+      value: 14
       objectReference: {fileID: 0}
     - target: {fileID: 4660719601325771399, guid: 5fce5f9d81cb36d4e8d04d1f8ea7e08e,
         type: 3}
@@ -2555,7 +2757,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   exteriorShip: {fileID: 0}
-  activated: 0
+  activated: 1
   resourceRequirement: 1
   resourceCount: 0
   resourcePipPrefab: {fileID: 4364623327053348872, guid: c93aa1eecbae35c448ae84a8fd966803,
@@ -4802,7 +5004,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1136984894}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -2.632, y: 1.698, z: 0}
+  m_LocalPosition: {x: -2.835, y: 1.988, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 1343496270}
@@ -4993,6 +5195,81 @@ AudioSource:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
+--- !u!1001 &1148884737
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 331577374}
+    m_Modifications:
+    - target: {fileID: 4660719601325771396, guid: 5fce5f9d81cb36d4e8d04d1f8ea7e08e,
+        type: 3}
+      propertyPath: m_Name
+      value: InteriorResource (3)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4660719601325771399, guid: 5fce5f9d81cb36d4e8d04d1f8ea7e08e,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -4.36
+      objectReference: {fileID: 0}
+    - target: {fileID: 4660719601325771399, guid: 5fce5f9d81cb36d4e8d04d1f8ea7e08e,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.73
+      objectReference: {fileID: 0}
+    - target: {fileID: 4660719601325771399, guid: 5fce5f9d81cb36d4e8d04d1f8ea7e08e,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4660719601325771399, guid: 5fce5f9d81cb36d4e8d04d1f8ea7e08e,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4660719601325771399, guid: 5fce5f9d81cb36d4e8d04d1f8ea7e08e,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4660719601325771399, guid: 5fce5f9d81cb36d4e8d04d1f8ea7e08e,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4660719601325771399, guid: 5fce5f9d81cb36d4e8d04d1f8ea7e08e,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4660719601325771399, guid: 5fce5f9d81cb36d4e8d04d1f8ea7e08e,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 18
+      objectReference: {fileID: 0}
+    - target: {fileID: 4660719601325771399, guid: 5fce5f9d81cb36d4e8d04d1f8ea7e08e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4660719601325771399, guid: 5fce5f9d81cb36d4e8d04d1f8ea7e08e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4660719601325771399, guid: 5fce5f9d81cb36d4e8d04d1f8ea7e08e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5fce5f9d81cb36d4e8d04d1f8ea7e08e, type: 3}
+--- !u!4 &1148884738 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4660719601325771399, guid: 5fce5f9d81cb36d4e8d04d1f8ea7e08e,
+    type: 3}
+  m_PrefabInstance: {fileID: 1148884737}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1169332289
 GameObject:
   m_ObjectHideFlags: 0
@@ -5444,7 +5721,7 @@ Transform:
   - {fileID: 736944282}
   - {fileID: 410399002}
   - {fileID: 764113774}
-  - {fileID: 2000661798}
+  - {fileID: 175075019}
   - {fileID: 1136984895}
   - {fileID: 886352689}
   m_Father: {fileID: 331577374}
@@ -6181,7 +6458,7 @@ MonoBehaviour:
     type: 3}
   m_PrefabInstance: {fileID: 2709358210105398729}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1780351523}
+  m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 1804d36180d53554aa40d6466ac2c68a, type: 3}
@@ -6640,108 +6917,6 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!1 &1780351523 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 2709358210058121325, guid: 990b27246ed4d83499c01f1565057762,
-    type: 3}
-  m_PrefabInstance: {fileID: 2709358210105398729}
-  m_PrefabAsset: {fileID: 0}
---- !u!82 &1780351527
-AudioSource:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1780351523}
-  m_Enabled: 1
-  serializedVersion: 4
-  OutputAudioMixerGroup: {fileID: 0}
-  m_audioClip: {fileID: 8300000, guid: f3648fbe7ea81d9418a00c9242f7987b, type: 3}
-  m_PlayOnAwake: 0
-  m_Volume: 1
-  m_Pitch: 1
-  Loop: 0
-  Mute: 0
-  Spatialize: 0
-  SpatializePostEffects: 0
-  Priority: 128
-  DopplerLevel: 1
-  MinDistance: 1
-  MaxDistance: 500
-  Pan2D: 0
-  rolloffMode: 0
-  BypassEffects: 0
-  BypassListenerEffects: 0
-  BypassReverbZones: 0
-  rolloffCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    - serializedVersion: 3
-      time: 1
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  panLevelCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  spreadCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  reverbZoneMixCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
 --- !u!1 &1802455800
 GameObject:
   m_ObjectHideFlags: 0
@@ -6818,85 +6993,6 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 60}
   m_EdgeRadius: 0
---- !u!1001 &1826829106
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 331577374}
-    m_Modifications:
-    - target: {fileID: 4493216524806061761, guid: 5de765d239be8b6419a76f97028bd244,
-        type: 3}
-      propertyPath: station
-      value: 
-      objectReference: {fileID: 736944283}
-    - target: {fileID: 4493216524806061761, guid: 5de765d239be8b6419a76f97028bd244,
-        type: 3}
-      propertyPath: ignited
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4493216524806061763, guid: 5de765d239be8b6419a76f97028bd244,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -2.008
-      objectReference: {fileID: 0}
-    - target: {fileID: 4493216524806061763, guid: 5de765d239be8b6419a76f97028bd244,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -1.2
-      objectReference: {fileID: 0}
-    - target: {fileID: 4493216524806061763, guid: 5de765d239be8b6419a76f97028bd244,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4493216524806061763, guid: 5de765d239be8b6419a76f97028bd244,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4493216524806061763, guid: 5de765d239be8b6419a76f97028bd244,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4493216524806061763, guid: 5de765d239be8b6419a76f97028bd244,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4493216524806061763, guid: 5de765d239be8b6419a76f97028bd244,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4493216524806061763, guid: 5de765d239be8b6419a76f97028bd244,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 19
-      objectReference: {fileID: 0}
-    - target: {fileID: 4493216524806061763, guid: 5de765d239be8b6419a76f97028bd244,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4493216524806061763, guid: 5de765d239be8b6419a76f97028bd244,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4493216524806061763, guid: 5de765d239be8b6419a76f97028bd244,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4493216524806061772, guid: 5de765d239be8b6419a76f97028bd244,
-        type: 3}
-      propertyPath: m_Name
-      value: Flame
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 5de765d239be8b6419a76f97028bd244, type: 3}
 --- !u!1 &1840125907
 GameObject:
   m_ObjectHideFlags: 0
@@ -7175,228 +7271,6 @@ Transform:
   m_Father: {fileID: 759190939}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 126.950005}
---- !u!1 &2000661797
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2000661798}
-  - component: {fileID: 2000661802}
-  - component: {fileID: 2000661801}
-  - component: {fileID: 2000661800}
-  - component: {fileID: 2000661799}
-  m_Layer: 14
-  m_Name: WeaponRepeaterStationRight
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2000661798
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2000661797}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -3.239, y: 0.99, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1343496270}
-  m_RootOrder: 6
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!82 &2000661799
-AudioSource:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2000661797}
-  m_Enabled: 1
-  serializedVersion: 4
-  OutputAudioMixerGroup: {fileID: 0}
-  m_audioClip: {fileID: 0}
-  m_PlayOnAwake: 0
-  m_Volume: 1
-  m_Pitch: 1
-  Loop: 0
-  Mute: 0
-  Spatialize: 0
-  SpatializePostEffects: 0
-  Priority: 128
-  DopplerLevel: 1
-  MinDistance: 1
-  MaxDistance: 500
-  Pan2D: 0
-  rolloffMode: 0
-  BypassEffects: 0
-  BypassListenerEffects: 0
-  BypassReverbZones: 0
-  rolloffCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    - serializedVersion: 3
-      time: 1
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  panLevelCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  spreadCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  reverbZoneMixCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
---- !u!114 &2000661800
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2000661797}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8c7d23d8f3aca3a4884c6731a036e9ff, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  exteriorShip: {fileID: 0}
-  activated: 1
-  resourceRequirement: 1
-  resourceCount: 0
-  resourcePipPrefab: {fileID: 4364623327053348872, guid: c93aa1eecbae35c448ae84a8fd966803,
-    type: 3}
-  addResourceSFX: {fileID: 8300000, guid: 6038f9e6cf9f0b6439b795cbf001c388, type: 3}
-  doEffectSFX: {fileID: 8300000, guid: c3cd6fad04cc7cb4da2f9c05c4f63081, type: 3}
-  disableSFX: {fileID: 8300000, guid: db9c42ae04551ce49978816123ad803b, type: 3}
-  boostMultPerResource: 1
-  duration: 25
-  maxStacks: 5
-  leftGun: 0
-  rightGun: 1
---- !u!58 &2000661801
-CircleCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2000661797}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  serializedVersion: 2
-  m_Radius: 0.25
---- !u!212 &2000661802
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2000661797}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: -1877029187
-  m_SortingLayer: 7
-  m_SortingOrder: 1
-  m_Sprite: {fileID: 21300000, guid: be3bc5205b1120f449639cb93098e8dc, type: 3}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 0.38, y: 0.37}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
 --- !u!1 &2037027500
 GameObject:
   m_ObjectHideFlags: 0
@@ -7872,14 +7746,39 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2709358210058121326, guid: 990b27246ed4d83499c01f1565057762,
         type: 3}
+      propertyPath: invincible
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2709358210058121326, guid: 990b27246ed4d83499c01f1565057762,
+        type: 3}
       propertyPath: explosionPrefab
       value: 
       objectReference: {fileID: 235347168054186532, guid: 16a500b5af459e843beea7841609fec4,
         type: 3}
     - target: {fileID: 2709358210058121326, guid: 990b27246ed4d83499c01f1565057762,
         type: 3}
-      propertyPath: fireRate
-      value: 6
+      propertyPath: crippledSpeedMult
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2709358210058121326, guid: 990b27246ed4d83499c01f1565057762,
+        type: 3}
+      propertyPath: currentHitPoints
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2709358210058121326, guid: 990b27246ed4d83499c01f1565057762,
+        type: 3}
+      propertyPath: playerID
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2709358210058121326, guid: 990b27246ed4d83499c01f1565057762,
+        type: 3}
+      propertyPath: fireRateLeft
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 2709358210058121326, guid: 990b27246ed4d83499c01f1565057762,
+        type: 3}
+      propertyPath: fireRateRight
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 2709358210058121327, guid: 990b27246ed4d83499c01f1565057762,
         type: 3}
@@ -8015,87 +7914,18 @@ PrefabInstance:
       propertyPath: m_TagString
       value: Player
       objectReference: {fileID: 0}
+    - target: {fileID: 4133146544276248415, guid: a8112b66de8a1ac45a8221ef55331b87,
+        type: 3}
+      propertyPath: pickupRadius
+      value: 0.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 4133146544276248415, guid: a8112b66de8a1ac45a8221ef55331b87,
+        type: 3}
+      propertyPath: playerID
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a8112b66de8a1ac45a8221ef55331b87, type: 3}
---- !u!1001 &4166267193701828184
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 331577374}
-    m_Modifications:
-    - target: {fileID: 241874445072127825, guid: 25228b40e8283f744ab81d3b828807b8,
-        type: 3}
-      propertyPath: m_Name
-      value: SteamVent
-      objectReference: {fileID: 0}
-    - target: {fileID: 5926554707891443729, guid: 25228b40e8283f744ab81d3b828807b8,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -4.2
-      objectReference: {fileID: 0}
-    - target: {fileID: 5926554707891443729, guid: 25228b40e8283f744ab81d3b828807b8,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.51
-      objectReference: {fileID: 0}
-    - target: {fileID: 5926554707891443729, guid: 25228b40e8283f744ab81d3b828807b8,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5926554707891443729, guid: 25228b40e8283f744ab81d3b828807b8,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5926554707891443729, guid: 25228b40e8283f744ab81d3b828807b8,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5926554707891443729, guid: 25228b40e8283f744ab81d3b828807b8,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0.84542227
-      objectReference: {fileID: 0}
-    - target: {fileID: 5926554707891443729, guid: 25228b40e8283f744ab81d3b828807b8,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.53409857
-      objectReference: {fileID: 0}
-    - target: {fileID: 5926554707891443729, guid: 25228b40e8283f744ab81d3b828807b8,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 14
-      objectReference: {fileID: 0}
-    - target: {fileID: 5926554707891443729, guid: 25228b40e8283f744ab81d3b828807b8,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5926554707891443729, guid: 25228b40e8283f744ab81d3b828807b8,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5926554707891443729, guid: 25228b40e8283f744ab81d3b828807b8,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -115.434006
-      objectReference: {fileID: 0}
-    - target: {fileID: 5926554707891443729, guid: 25228b40e8283f744ab81d3b828807b8,
-        type: 3}
-      propertyPath: m_LocalScale.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5926554707891443729, guid: 25228b40e8283f744ab81d3b828807b8,
-        type: 3}
-      propertyPath: m_LocalScale.y
-      value: 1
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 25228b40e8283f744ab81d3b828807b8, type: 3}
 --- !u!1001 &4759354057526064230
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -8220,7 +8050,7 @@ PrefabInstance:
     - target: {fileID: 4960148900392517662, guid: 0faf1b6dcc28102478e1bf949873c5bd,
         type: 3}
       propertyPath: m_RootOrder
-      value: 15
+      value: 13
       objectReference: {fileID: 0}
     - target: {fileID: 4960148900392517662, guid: 0faf1b6dcc28102478e1bf949873c5bd,
         type: 3}
@@ -8276,75 +8106,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 6843851466985708257}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &5428338952980910459
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 331577374}
-    m_Modifications:
-    - target: {fileID: 5428338951377334393, guid: 4a9a2a554924169449c262911cfacac3,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -1.9
-      objectReference: {fileID: 0}
-    - target: {fileID: 5428338951377334393, guid: 4a9a2a554924169449c262911cfacac3,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.63
-      objectReference: {fileID: 0}
-    - target: {fileID: 5428338951377334393, guid: 4a9a2a554924169449c262911cfacac3,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5428338951377334393, guid: 4a9a2a554924169449c262911cfacac3,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5428338951377334393, guid: 4a9a2a554924169449c262911cfacac3,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5428338951377334393, guid: 4a9a2a554924169449c262911cfacac3,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5428338951377334393, guid: 4a9a2a554924169449c262911cfacac3,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5428338951377334393, guid: 4a9a2a554924169449c262911cfacac3,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 13
-      objectReference: {fileID: 0}
-    - target: {fileID: 5428338951377334393, guid: 4a9a2a554924169449c262911cfacac3,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5428338951377334393, guid: 4a9a2a554924169449c262911cfacac3,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5428338951377334393, guid: 4a9a2a554924169449c262911cfacac3,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5428338951377334661, guid: 4a9a2a554924169449c262911cfacac3,
-        type: 3}
-      propertyPath: m_Name
-      value: DebrisMedium
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 4a9a2a554924169449c262911cfacac3, type: 3}
 --- !u!1001 &6843851466985708257
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -8426,7 +8187,7 @@ PrefabInstance:
     - target: {fileID: 1886941738297210849, guid: 07a4a8ccb7b1f834ba6fcc9e41c7de1f,
         type: 3}
       propertyPath: m_RootOrder
-      value: 18
+      value: 16
       objectReference: {fileID: 0}
     - target: {fileID: 1886941738297210849, guid: 07a4a8ccb7b1f834ba6fcc9e41c7de1f,
         type: 3}

--- a/Assets/Scenes/NickTest.unity.meta
+++ b/Assets/Scenes/NickTest.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 600e510587b19f04cb869490f8d11138
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Exterior/Enemies/Mission/AsteroidBeltMission.asset
+++ b/Assets/Scripts/Exterior/Enemies/Mission/AsteroidBeltMission.asset
@@ -41,6 +41,11 @@ MonoBehaviour:
         _pattern: 7
         _zone: 1
         _enemyType: 7
+    - _duration: 2
+      _squadron:
+        _pattern: 2
+        _zone: 1
+        _enemyType: 14
     - _duration: 15
       _squadron:
         _pattern: 7
@@ -73,11 +78,11 @@ MonoBehaviour:
         _pattern: 8
         _zone: 1
         _enemyType: 12
-    - _duration: 3
+    - _duration: 2
       _squadron:
-        _pattern: 1
+        _pattern: 2
         _zone: 1
-        _enemyType: 12
+        _enemyType: 14
     - _duration: 3
       _squadron:
         _pattern: 8
@@ -91,6 +96,11 @@ MonoBehaviour:
     - _duration: 3
       _squadron:
         _pattern: 8
+        _zone: 1
+        _enemyType: 12
+    - _duration: 5
+      _squadron:
+        _pattern: 1
         _zone: 1
         _enemyType: 12
     - _duration: 5
@@ -120,6 +130,11 @@ MonoBehaviour:
         _pattern: 7
         _zone: 0
         _enemyType: 7
+    - _duration: 2
+      _squadron:
+        _pattern: 2
+        _zone: 1
+        _enemyType: 14
     - _duration: 5
       _squadron:
         _pattern: 7
@@ -196,10 +211,10 @@ MonoBehaviour:
         _pattern: 2
         _zone: 5
         _enemyType: 6
-    - _duration: 5
+    - _duration: 8
       _squadron:
         _pattern: 7
-        _zone: 1
+        _zone: 5
         _enemyType: 2
     - _duration: 5
       _squadron:

--- a/Assets/Scripts/Exterior/Enemies/SpawnManager.cs
+++ b/Assets/Scripts/Exterior/Enemies/SpawnManager.cs
@@ -326,8 +326,9 @@ public class SpawnManager : MonoBehaviour
     public void JettisonObject(GameObject interiorObject, Vector3 dir)
     {
         // just get left or right
-        if (dir.x < 0) dir = new Vector3(-1, 0, 0);
-        if (dir.x > 0) dir = new Vector3(1, 0, 0);
+        Vector3 spawnDir = Vector3.zero;
+        if (dir.x < 0) spawnDir = new Vector3(-1, 0, 0);
+        if (dir.x > 0) spawnDir = new Vector3(1, 0, 0);
         
         GameObject playerShip = GetPlayerShip();
 
@@ -335,8 +336,9 @@ public class SpawnManager : MonoBehaviour
         {
             interiorObject.SetActive(false);
 
-            GameObject r = SpawnResource(playerShip.transform.position + dir * 0.5f);
-            r.GetComponent<ExternalResourcePickup>().DelayCollisionUntilExit();
+            GameObject r = SpawnResource(playerShip.transform.position + spawnDir * 0.5f);
+            r.GetComponent<SpaceDrift>().SetDrifDirection(dir);
+            r.GetComponent<ExternalResourcePickup>().DelayPickup(1.5f);
             r.AddComponent<JettisonedObject>();
             r.GetComponent<JettisonedObject>().SetInteriorObject(interiorObject);
         }

--- a/Assets/Scripts/Exterior/ExternalResourcePickup.cs
+++ b/Assets/Scripts/Exterior/ExternalResourcePickup.cs
@@ -5,7 +5,7 @@ using System.Linq;
 
 public class ExternalResourcePickup : MonoBehaviour
 {
-    private bool delayUntilExit = false;
+    private float delayPickup = 0;
 
     private void Start()
     {
@@ -14,38 +14,65 @@ public class ExternalResourcePickup : MonoBehaviour
 
     private void Update()
     {
-        
+        if (delayPickup > 0) delayPickup -= Time.deltaTime;
+
+        if (delayPickup <= 0 && collidedOnDelay.Count > 0)
+        {
+            Pickup();
+        }
     }
+
+    List<GameObject> collidedOnDelay = new List<GameObject>();
 
     private void OnTriggerEnter2D(Collider2D collision)
     {
-        if (collision.tag == "Player" && !delayUntilExit)
+        if (collision.tag == "Player")
         {
-            InteriorManager interiorManager = GameObject.FindObjectOfType<InteriorManager>();
-
-            if (interiorManager != null)
+            if (delayPickup > 0)
             {
-                JettisonedObject jo = GetComponent<JettisonedObject>();
-                if (jo != null)
-                {
-                    interiorManager.ReclaimJettisonedObject(jo.InteriorObject);
-                } else
-                {
-                    interiorManager.SpawnResource();
-                }
+                collidedOnDelay.Add(collision.gameObject);
             }
-
-            Destroy(gameObject);
+            else
+            {
+                Pickup();
+            }
         }
+    }
+
+    private void Pickup()
+    {
+        collidedOnDelay.Clear();
+
+        InteriorManager interiorManager = GameObject.FindObjectOfType<InteriorManager>();
+
+        if (interiorManager != null)
+        {
+            JettisonedObject jo = GetComponent<JettisonedObject>();
+            if (jo != null)
+            {
+                interiorManager.ReclaimJettisonedObject(jo.InteriorObject);
+            }
+            else
+            {
+                interiorManager.SpawnResource();
+            }
+        }
+
+        Destroy(gameObject);
     }
 
     private void OnTriggerExit2D(Collider2D collision)
     {
-        if (delayUntilExit) delayUntilExit = false;
+        if (delayPickup > 0) delayPickup = 0;
+
+        if (collidedOnDelay.Count > 0)
+        {
+            collidedOnDelay.Remove(collision.gameObject);
+        }
     }
 
-    public void DelayCollisionUntilExit()
+    public void DelayPickup(float time)
     {
-        delayUntilExit = true;
+        delayPickup = time;
     }
 }

--- a/Assets/Scripts/Exterior/SpaceDrift.cs
+++ b/Assets/Scripts/Exterior/SpaceDrift.cs
@@ -6,16 +6,23 @@ using System.Linq;
 public class SpaceDrift : MonoBehaviour
 {
     [SerializeField] float speed = 0.5f;
+    [SerializeField] Vector2 direction = Vector2.down;
+    [SerializeField] Vector2 diftDirection = Vector2.zero;
 
     private void Start()
     {
         
     }
 
+    public void SetDrifDirection(Vector2 newDirection)
+    {
+        diftDirection = newDirection;
+    }
+
     private void Update()
     {
         Vector2 newPos = transform.position;
-        newPos.y -= speed * Time.deltaTime;
+        newPos += (direction + diftDirection) * speed * Time.deltaTime;
 
         transform.position = newPos;
     }

--- a/Assets/Scripts/Interior/InteriorManager.cs
+++ b/Assets/Scripts/Interior/InteriorManager.cs
@@ -119,6 +119,9 @@ public class InteriorManager : MonoBehaviour
     public void SpawnResource()
     {
         GameObject resource = GameObject.Instantiate<GameObject>(resourcePrefab, resourceSpawn.position, Quaternion.identity);
+        resource.transform.position += new Vector3(Random.Range(-0.1f, 0.1f), Random.Range(-0.1f, 0.1f), 0);
+        resource.transform.Rotate(Quaternion.Euler(0, 0, UnityEngine.Random.Range(0f, 360f)).eulerAngles);
+
         if (transform.parent != null) resource.transform.SetParent(transform.parent);
         spawnedResources.Add(resource);
 
@@ -128,8 +131,10 @@ public class InteriorManager : MonoBehaviour
     public void ReclaimJettisonedObject(GameObject reclaimedObject)
     {
         Transform t = reclaimedObject.transform;
+        
+        t.position = resourceSpawn.position + new Vector3(Random.Range(-0.1f, 0.1f), Random.Range(-0.1f, 0.1f), 0);
+        if (reclaimedObject.tag != "Player") t.Rotate(Quaternion.Euler(0, 0, UnityEngine.Random.Range(0f, 360f)).eulerAngles);
 
-        t.position = resourceSpawn.position;
         reclaimedObject.SetActive(true);
 
         aSource.PlayOneShot(loadItemSfX, 0.5f);

--- a/Assets/Scripts/Interior/InteriorPlayer.cs
+++ b/Assets/Scripts/Interior/InteriorPlayer.cs
@@ -14,6 +14,8 @@ public class InteriorPlayer : MonoBehaviour
 
     [SerializeField] PlayerID playerID = PlayerID.Player1;
 
+    [SerializeField] float pickupRadius = 0.3f;
+
     Rigidbody2D rigidbody2D;
 
     private GameObject heldItem;
@@ -40,6 +42,8 @@ public class InteriorPlayer : MonoBehaviour
     {
         UpdatePickup();
         UpdateUse();
+
+        Debug.DrawLine(transform.position, transform.position + Vector3.right * pickupRadius);
     }
 
     private void FixedUpdate()
@@ -90,9 +94,8 @@ public class InteriorPlayer : MonoBehaviour
         if ((playerID == PlayerID.Player1 && (Input.GetKeyDown(KeyCode.G) || Input.GetButtonDown("A1")))
             || (playerID == PlayerID.Player2 && (Input.GetKeyDown(KeyCode.Space) || Input.GetButtonDown("A2"))))
         {
-            if (heldItem == null && overItems.Count > 0)
+            if (heldItem == null)
             {
-                audioSource.Play();
                 PickupItem();
             } else
             {
@@ -117,22 +120,58 @@ public class InteriorPlayer : MonoBehaviour
         }
     }
 
+    /*
+    private GameObject GetClosestPickupItem()
+    {
+        GameObject closest = null;
+        float closestDist = 99999;
+
+        for (int i = 0; i < overItems.Count; i++)
+        {
+            if (overItems[i] != null)
+            {
+                float distance = ((Vector2)overItems[i].transform.position - (Vector2)transform.position).magnitude;
+                if (distance < closestDist)
+                {
+                    closest = overItems[i];
+                    closestDist = distance;
+                }
+            }
+        }
+
+        return closest;
+    }
+    */
+    
     private void PickupItem()
     {
+        Collider2D[] hitColliders = Physics2D.OverlapCircleAll(transform.position, pickupRadius);
+        int i = 0;
+        while (i < hitColliders.Length)
+        {
+            if (hitColliders[i].tag == "Interior Resource" || hitColliders[i].tag == "Tool")
+            {
+                //Debug.Log("Target Acquired!");
+                heldItem = hitColliders[i].gameObject;
+                heldItem.GetComponent<PickupItem>().Pickup(this);
+                audioSource.Play();
+                break;
+            }
+            i++;
+        }
+
+        /*
         if (heldItem == null)
         {
-            //Debug.Log("Picked up resource!");
-
-            heldItem = overItems[0];
-            overItems.RemoveAt(0);
             while ((heldItem == null || heldItem.activeSelf) && overItems.Count > 0)
             {
-                heldItem = overItems[0];
-                overItems.RemoveAt(0);
+                heldItem = GetClosestPickupItem();
+                overItems.Remove(heldItem);
             }
             
             if (heldItem != null && heldItem.activeSelf) heldItem.GetComponent<PickupItem>().Pickup(this);
         }
+        */
     }
 
     public void DropItem()
@@ -159,7 +198,7 @@ public class InteriorPlayer : MonoBehaviour
     {
         if ((collision.tag == "Interior Resource" || collision.tag == "Tool") && !overItems.Contains(collision.gameObject) && heldItem != collision.gameObject)
         {
-            overItems.Add(collision.gameObject);
+            //overItems.Add(collision.gameObject);
             //Debug.Log("Interior Player over item " + collision.tag.ToString() + " over items count = " + overItems.Count.ToString());
         }
         else
@@ -172,7 +211,7 @@ public class InteriorPlayer : MonoBehaviour
     {
         if (collision.tag == "Interior Resource" || collision.tag == "Tool")
         {
-            overItems.Remove(collision.gameObject);
+            //overItems.Remove(collision.gameObject);
             //Debug.Log("Interior Player no longer over item " + collision.tag.ToString() + " over items count = " + overItems.Count.ToString());
         } else
         {

--- a/Assets/Scripts/Interior/Stations/EngineStation.cs
+++ b/Assets/Scripts/Interior/Stations/EngineStation.cs
@@ -3,12 +3,59 @@ using System.Collections.Generic;
 using UnityEngine;
 using System.Linq;
 
-public class EngineStation : DurationStation
+public class EngineStation : Station
 {
+    [SerializeField] float boostMultPerResource = 0.25f;
+    [SerializeField] float duration = 30f;
+    [SerializeField] int maxStacks = 3;
+
+    protected float Duration { get { return duration; } }
+
+    protected override void InitStation()
+    {
+        if (ResourceCount > 0)
+        {
+            // init with stacks already!
+            for (int i = 0; i < ResourceCount; i++)
+            {
+                if (i < maxStacks) ProcessResource(null);
+            }
+        }
+    }
+
     protected override void ProcessResource(InteriorResource r)
     {
-        Ship.BoostSpeedMult(r.Value * 2.5f, r.Value * Duration);
-        base.ProcessResource(r);
+        float value = r != null ? r.Value : 1;
+        Ship.AddBoostSpeedMultStack(value * boostMultPerResource, value * Duration);
+        if (r != null) base.ProcessResource(r);
+    }
+
+    protected override void IncreaseResources(InteriorResource r)
+    {
+        if (Ship.NumEngineBoostStacks < maxStacks)
+        {
+            ResourceCount++;
+            if (ResourceCount >= ResourceRequirement)
+            {
+                ProcessResource(r);
+                ResourceCount = 0;
+            }
+        }
+    }
+
+    protected override void InitPips()
+    {
+        resourcePips = new ResourcePip[maxStacks];
+
+        PositionPips(maxStacks);
+    }
+
+    protected override void UpdateResourcePips()
+    {
+        for (int i = 0; i < ResourcePips.Length; i++)
+        {
+            ResourcePips[i].SetFull(i < Ship.NumEngineBoostStacks);
+        }
     }
 
     public override void Deactivate()
@@ -23,5 +70,10 @@ public class EngineStation : DurationStation
         base.Reactivate();
 
         Ship.CrippleMovementMult(1f);
+    }
+
+    protected override void StationUpdate()
+    {
+        UpdateResourcePips();
     }
 }

--- a/Assets/Scripts/Interior/Stations/ShipBonusStack.cs
+++ b/Assets/Scripts/Interior/Stations/ShipBonusStack.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+[Serializable]
+public class ShipBonusStack
+{
+    public float Amount = 1;
+    public float Duration = 0;
+
+    public ShipBonusStack(float amount, float duration)
+    {
+        this.Amount = amount;
+        this.Duration = duration;
+    }
+}

--- a/Assets/Scripts/Interior/Stations/ShipBonusStack.cs.meta
+++ b/Assets/Scripts/Interior/Stations/ShipBonusStack.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 09cc4af7792925a4091af39ac253a401
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Interior/Stations/WeaponRepeaterStation.cs
+++ b/Assets/Scripts/Interior/Stations/WeaponRepeaterStation.cs
@@ -3,25 +3,90 @@ using System.Collections.Generic;
 using UnityEngine;
 using System.Linq;
 
-public class WeaponRepeaterStation : DurationStation
+public class WeaponRepeaterStation : Station
 {
+    [SerializeField] float boostMultPerResource = 1f;
+    [SerializeField] float duration = 30f;
+    [SerializeField] int maxStacks = 3;
+    [SerializeField] bool leftGun = true;
+    [SerializeField] bool rightGun = true;
+
+    protected float Duration { get { return duration; } }
+
+    protected override void InitStation()
+    {
+        if (ResourceCount > 0)
+        {
+            // init with stacks already!
+            for (int i = 0; i < ResourceCount; i++)
+            {
+                if (i < maxStacks) ProcessResource(null);
+            }
+        }
+    }
+
     protected override void ProcessResource(InteriorResource r)
     {
-        Ship.BoostFireRate(r.Value * 3f, r.Value * Duration);
-        base.ProcessResource(r);
+        float value = r != null ? r.Value : 1;
+
+        if (leftGun) Ship.AddBoostFireRateStackLeft(value * boostMultPerResource, value * Duration);
+        if (rightGun) Ship.AddBoostFireRateStackRight(value * boostMultPerResource, value * Duration);
+
+
+        if (r != null) base.ProcessResource(r);
+    }
+
+    protected override void IncreaseResources(InteriorResource r)
+    {
+        if (GetCurrentStacksOnShip() < maxStacks)
+        {
+            ResourceCount++;
+            if (ResourceCount >= ResourceRequirement)
+            {
+                ProcessResource(r);
+                ResourceCount = 0;
+            }
+        }
+    }
+
+    private int GetCurrentStacksOnShip()
+    {
+        return (leftGun ? Ship.NumFireRateBoostStacksLeft : Ship.NumFireRateBoostStacksRight);
+    }
+
+    protected override void InitPips()
+    {
+        resourcePips = new ResourcePip[maxStacks];
+
+        PositionPips(maxStacks);
+    }
+
+    protected override void UpdateResourcePips()
+    {
+        for (int i = 0; i < ResourcePips.Length; i++)
+        {
+            ResourcePips[i].SetFull(i < GetCurrentStacksOnShip());
+        }
     }
 
     public override void Deactivate()
     {
         base.Deactivate();
 
-        Ship.DisableFiring();
+        if (leftGun) Ship.DisableFiringLeft();
+        if (rightGun) Ship.DisableFiringRight();
     }
 
     public override void Reactivate()
     {
         base.Reactivate();
 
-        Ship.EnableFiring();
+        if (leftGun) Ship.EnableFiringLeft();
+        if (rightGun) Ship.EnableFiringRight();
+    }
+
+    protected override void StationUpdate()
+    {
+        UpdateResourcePips();
     }
 }

--- a/ProjectSettings/InputManager.asset
+++ b/ProjectSettings/InputManager.asset
@@ -150,6 +150,38 @@ InputManager:
     axis: 2
     joyNum: 0
   - serializedVersion: 3
+    m_Name: TriggerLeft1
+    descriptiveName: 
+    descriptiveNegativeName: 
+    negativeButton: 
+    positiveButton: 
+    altNegativeButton: 
+    altPositiveButton: 
+    gravity: 0
+    dead: 0.19
+    sensitivity: 1
+    snap: 0
+    invert: 0
+    type: 2
+    axis: 8
+    joyNum: 1
+  - serializedVersion: 3
+    m_Name: TriggerRight1
+    descriptiveName: 
+    descriptiveNegativeName: 
+    negativeButton: 
+    positiveButton: 
+    altNegativeButton: 
+    altPositiveButton: 
+    gravity: 0
+    dead: 0.19
+    sensitivity: 1
+    snap: 0
+    invert: 0
+    type: 2
+    axis: 9
+    joyNum: 1
+  - serializedVersion: 3
     m_Name: Horizontal1
     descriptiveName: 
     descriptiveNegativeName: 
@@ -293,6 +325,38 @@ InputManager:
     type: 0
     axis: 0
     joyNum: 0
+  - serializedVersion: 3
+    m_Name: TriggerLeft2
+    descriptiveName: 
+    descriptiveNegativeName: 
+    negativeButton: 
+    positiveButton: 
+    altNegativeButton: 
+    altPositiveButton: 
+    gravity: 0
+    dead: 0.19
+    sensitivity: 1
+    snap: 0
+    invert: 0
+    type: 2
+    axis: 8
+    joyNum: 2
+  - serializedVersion: 3
+    m_Name: TriggerRight2
+    descriptiveName: 
+    descriptiveNegativeName: 
+    negativeButton: 
+    positiveButton: 
+    altNegativeButton: 
+    altPositiveButton: 
+    gravity: 0
+    dead: 0.19
+    sensitivity: 1
+    snap: 0
+    invert: 0
+    type: 2
+    axis: 9
+    joyNum: 2
   - serializedVersion: 3
     m_Name: Horizontal2
     descriptiveName: 

--- a/ProjectSettings/Physics2DSettings.asset
+++ b/ProjectSettings/Physics2DSettings.asset
@@ -53,4 +53,4 @@ Physics2DSettings:
   m_ColliderAsleepColor: {r: 0.5686275, g: 0.95686275, b: 0.54509807, a: 0.36078432}
   m_ColliderContactColor: {r: 1, g: 0, b: 1, a: 0.6862745}
   m_ColliderAABBColor: {r: 1, g: 1, b: 0, a: 0.2509804}
-  m_LayerCollisionMatrix: ff7fffffff7fffffff7fffffffffffffff7fffffff7fffffffffffffffffffffff1bffffff05ffffff12ffffff11fdffff1dfdffff60fdffff60f5ffc800fdfffffffdffff07feffffffffffffbfd7fffffffffffffff7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+  m_LayerCollisionMatrix: ff7fffffff7fffffff7fffffffffffffff7fffffff7fffffffffffffffffffffff1bffffff05ffffff12ffffff11ffffff1dfdffff60fdffff60f5ffc800fdfffffffdffff0ffeffffffffffffbfd7fffffffffffffff7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff


### PR DESCRIPTION
Changed Engine and Repeater station to track respective stacks on the exterior ship, and increased their max stacks. (The work like a "fuel" gague)

Added second gun, each gun controlled with triggers on controller.

Removed spread station and added second repeater station, so each gun has independent "ammunition".

Exterior player (pilot) can press B to d a "barrel roll" granting them limited invincibility frames. can only do if engines not disabled and have "fuel".

Firing bullets drains repeater station stacks. Barrel Rolling drains engine stacks.

Sprinkled in more gold Resource meteors throughout wave 1.

Enemy bullets now hit meteors (but don't do anything).

Removed accidental spread shot on PlainJane enemy ships.

Refactored interior player pickup code so it's less janky.